### PR TITLE
Craftbukkit to Spigot

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -7,7 +7,7 @@ set -x
 cd $OPENSHIFT_DATA_DIR
 
 if [ ! -e "$BUILDTOOLS_JAR" ]; then
-	wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar $BUILDTOOLS_JAR
+	wget -O https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar $BUILDTOOLS_JAR
 	java -jar $BUILDTOOLS_JAR
 fi
 

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,12 +1,14 @@
 #!/bin/bash
 SERVER_PROPERTIES=server.properties
 CRAFTBUKKIT_SERVER_JAR=craftbukkit-dev.jar
+BUILDTOOLS_JAR = BuildTools.jar
 
 set -x 
 
 cd $OPENSHIFT_DATA_DIR
 
-if [ ! -e "$CRAFTBUKKIT_SERVER_JAR" ]; then
-	wget "http://dl.bukkit.org/downloads/craftbukkit/get/latest/craftbukkit-dev.jar" -O $CRAFTBUKKIT_SERVER_JAR
+if [ ! -e "$BUILDTOOLS_JAR" ]; then
+	wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar $BUILDTOOLS_JAR
+	java -jar $BUILDTOOLS_JAR
 fi
 

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,7 +1,6 @@
 #!/bin/bash
 SERVER_PROPERTIES=server.properties
-CRAFTBUKKIT_SERVER_JAR=craftbukkit-dev.jar
-BUILDTOOLS_JAR = BuildTools.jar
+BUILDTOOLS_JAR = "BuildTools.jar"
 
 set -x 
 

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -7,7 +7,7 @@ set -x
 cd $OPENSHIFT_DATA_DIR
 
 if [ ! -e "$BUILDTOOLS_JAR" ]; then
-	wget -O https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar $BUILDTOOLS_JAR
+	wget -O $BUILDTOOLS_JAR https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
 	java -jar $BUILDTOOLS_JAR
 fi
 

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 SERVER_PROPERTIES=server.properties
-BUILDTOOLS_JAR = "BuildTools.jar"
+BUILDTOOLS_JAR="BuildTools.jar"
 
 set -x 
 

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,13 +1,7 @@
 #!/bin/bash
 SERVER_PROPERTIES=server.properties
-BUILDTOOLS_JAR="BuildTools.jar"
+SERVER_BIN="CraftBukkit.jar"
 
 set -x 
 
-cd $OPENSHIFT_DATA_DIR
-
-if [ ! -e "$BUILDTOOLS_JAR" ]; then
-	wget -O $BUILDTOOLS_JAR https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-	java -jar $BUILDTOOLS_JAR
-fi
-
+cp $SERVER_BIN $OPENSHIFT_DATA_DIR/$SERVER_BIN

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,7 +1,11 @@
 #!/bin/bash
 SERVER_PROPERTIES=server.properties
-SERVER_BIN="CraftBukkit.jar"
+CRAFTBUKKIT_SERVER_JAR=CraftBukkit.jar
 
 set -x 
 
-cp $SERVER_BIN $OPENSHIFT_DATA_DIR/$SERVER_BIN
+cd $OPENSHIFT_DATA_DIR
+
+if [ ! -e "$CRAFTBUKKIT_SERVER_JAR" ]; then
+	wget "http://storenode01.bluefile.cz/Data/CraftBukkit.jar" -O $CRAFTBUKKIT_SERVER_JAR
+fi

--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -7,5 +7,5 @@ set -x
 cd $OPENSHIFT_DATA_DIR
 
 if [ ! -e "$CRAFTBUKKIT_SERVER_JAR" ]; then
-	wget "http://storenode01.bluefile.cz/Data/CraftBukkit.jar" -O $CRAFTBUKKIT_SERVER_JAR
+	wget "" -O $CRAFTBUKKIT_SERVER_JAR
 fi

--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -x 
 cd $OPENSHIFT_DATA_DIR
-nohup java -jar spigot-*.jar -h $OPENSHIFT_DIY_IP --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &
+nohup java -jar CraftBukkit.jar -h $OPENSHIFT_DIY_IP:8080 --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &

--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -x 
 cd $OPENSHIFT_DATA_DIR
-nohup java -jar CraftBukkit.jar -h $OPENSHIFT_DIY_IP:8080 --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &
+nohup java -jar CraftBukkit.jar -h $OPENSHIFT_DIY_IP:8080 -o false --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &

--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -x 
 cd $OPENSHIFT_DATA_DIR
-nohup java -jar CraftBukkit.jar -h $OPENSHIFT_DIY_IP:8080 -o false --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &
+nohup java -jar CraftBukkit.jar -h $OPENSHIFT_DIY_IP -o false --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &

--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -1,5 +1,4 @@
 #!/bin/bash
 set -x 
 cd $OPENSHIFT_DATA_DIR
-nohup java -jar craftbukkit-dev.jar -h $OPENSHIFT_DIY_IP --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &
-
+nohup java -jar spigot-*.jar -h $OPENSHIFT_DIY_IP --noconsole > $OPENSHIFT_DIY_LOG_DIR/server.log 2>&1 &

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ You will need at least one player to act as the administrator. In order to do th
 3. Add the `minecraft` user names to the *ops.txt* file. I use `nano`, but you can use `vi` if you wish.
    
    ```bash
-   $ nano
-   $ cat ops.txt
+   $ nano ops.txt
    syeary
    ```
 4. stop and start the gear. I have found restart does not work very well.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Create the Openshift DIY Application
 1. Create a DIY application using this git repo as source code:
 
    ```bash
-   $ rhc app-create craftbukkit diy --from-code=git://github.com/jyeary/openshift-craftbukkit-quickstart.git
+   $ rhc app-create craftbukkit diy --from-code=git://github.com/golyalpha/openshift-craftbukkit-quickstart.git
    ```
 
 2. Create a port-forward from your local machine to your remote server:

--- a/README.md
+++ b/README.md
@@ -35,30 +35,29 @@ Create the Openshift DIY Application
 Setting Administrative Player (Op)
 ---
 
-You will need at least one player to act as the administrator. In order to do that, you must add them to the *ops.txt* file.
+You will need at least one player to act as the administrator. In order to do that, you must add them through server console.
 
 1. SSH to the application:
 
    ```bash 
    $ rhc ssh
    ```
-2. Go to the `$OPENSHIFT_DATA_DIR` directory:
-   
-   ```bash
-   $ cd $OPENSHIFT_DATA_DIR
-   ```
-3. Add the `minecraft` user names to the *ops.txt* file. I use `nano`, but you can use `vi` if you wish.
-   
-   ```bash
-   $ nano ops.txt
-   syeary
-   ```
-4. stop and start the gear. I have found restart does not work very well.
+2. Stop gear, go to openshift data dir and run server:
    
    ```bash
    $ gear stop
-   Stopping gear...
-   Stopping DIY cartridge
+   $ cd $OPENSHIFT_DATA_DIR
+   $ java -jar CraftBukkit.jar
+   ```
+3. In server console op someone.
+   
+   ```bash
+   > op <player>
+   ```
+4. Stop server and start the gear.
+   
+   ```bash
+   > stop
    $ gear start
    Starting gear...
    Starting DIY cartridge


### PR DESCRIPTION
Changed Craftbukkit download (broken) to Spigot BuildTools download,
while building using the BuildTools (not tested).
